### PR TITLE
Fixed DOCDOKU_PLM_VERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Launch your browser once artifacts are all deployed
 
 Get platform health
 
-	./platofrm-ctl heatlh
+	./platform-ctl heatlh
 
 List platform containers
 

--- a/platform-ctl
+++ b/platform-ctl
@@ -30,7 +30,7 @@ DOCDOKU_WEB_FRONT_SSH_URL=git@github.com:docdoku/docdoku-web-front.git
 DOCDOKU_WEB_FRONT_HTTPS_URL=https://github.com/docdoku/docdoku-web-front.git
 DOCDOKU_PLM_SAMPLE_SSH_URL=git@github.com:docdoku/docdoku-plm-sample-data.git
 DOCDOKU_PLM_SAMPLE_HTTPS_URL=https://github.com/docdoku/docdoku-plm-sample-data.git
-DOCDOKU_PLM_VERSION=2.5.3-SNAPSHOT
+DOCDOKU_PLM_VERSION=2.5.5
 
 # Resolve script dir (may be a symlink or sourced script)
 dir () {


### PR DESCRIPTION
platform-ctl up was throwing an error because of the **.2.5.3-snapshot.ear didn't exist as the version have changed to 2.5.5

Changing the DOCDOKU_PLM_VERSION variable to 2.5.5, the bash scripts now runs fine.