### PR TITLE
Update image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
       - db
 
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: wurstmeister/zookeeper:latest
     networks:
       - network
 

--- a/start.sh
+++ b/start.sh
@@ -42,9 +42,14 @@ then
     echo 'Keystore found'
 else
     echo 'Generating keystore...'
-    keytool \
+    # keytool
+    docker run -it --rm \
+     -v $(pwd):$(pwd) \
+     -w $(pwd) \
+     azul/zulu-openjdk:8u232 \
+     keytool \
      -genseckey \
-     -keystore $(pwd)/keystore \
+     -keystore keystore \
      -storetype ${STORETYPE} \
      -alias ${KEYALIAS} \
      -keyalg ${KEYALG} \


### PR DESCRIPTION
- Run keytool using the image

  Used to solve the `keytool: command not found` problem.

  The image `azul/zulu-openjdk:8u232` is base image of `payara/server-full:5.194` and  `docdoku/docdoku-plm-server`,
  see https://github.com/docdoku/docdoku-plm-server/blob/ca34dac6c89d3cea64a735b538f3b48d69bb1eaa/docker/payara/Dockerfile#L1C6-L1C24
 and https://github.com/payara/Payara/blob/payara-server-5.194/appserver/extras/docker-images/src/main/resources/payaraserver-node/Dockerfile

- Replace `wurstmeister/zookeeper` with `latest` tag

  Used to solve the problem of format being abandoned
  ```bash
  docker pull wurstmeister/zookeeper:3.4.6
  3.4.6: Pulling from wurstmeister/zookeeper
  [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/wurstmeister/zookeeper:3.4.6 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
  ```